### PR TITLE
Use column type text instead of json for repeater column

### DIFF
--- a/updates/smallextensions_tables.php
+++ b/updates/smallextensions_tables.php
@@ -20,7 +20,7 @@ class SmallExtensionsTables extends Migration
             $table->text('text')->nullable();
             $table->boolean('switch')->nullable();
             $table->datetime('datetime')->nullable();
-            $table->json('repeater')->nullable();
+            $table->text('repeater')->nullable();
             $table->timestamps();
         });
 


### PR DESCRIPTION
This is needed because of column type json would raise problems on some MySQL setups and don't let plugin to install normally.