### PR TITLE
API Code field named wrongly as Datetime field.

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -245,12 +245,12 @@ class Plugin extends PluginBase {
       /*
       * API code field
       */
-      if(Settings::get('blog_custom_fields_datetime')) {
+      if(Settings::get('blog_custom_fields_api_code')) {
 
         $widget->addSecondaryTabFields([
-          'custom_fields[datetime]' => [
-            'label' => ( Settings::get('blog_custom_fields_datetime_label') ? Settings::get('blog_custom_fields_datetime_label') : 'janvince.smallextensions::lang.labels.custom_fields_datetime'),
-            'comment' => 'janvince.smallextensions::lang.labels.custom_fields_datetime_description',
+          'custom_fields[api_code]' => [
+            'label' => ( Settings::get('blog_custom_fields_api_code_label') ? Settings::get('blog_custom_fields_api_code_label') : 'janvince.smallextensions::lang.labels.custom_fields_api_code'),
+            'comment' => 'janvince.smallextensions::lang.labels.custom_fields_api_code_description',
             'span' => 'full',
             'type' => 'text',
             'deferredBinding' => 'true',


### PR DESCRIPTION
Change name of the API Code field area as it did not display in the appropriate area of the More tab in the blog post editor. Seemed to not save in the database as well so this is the suggestion.
Tested to be working.